### PR TITLE
Changed ASM version used from 4 to 5

### DIFF
--- a/src/main/java/cn/annoreg/asm/DelegateGenerator.java
+++ b/src/main/java/cn/annoreg/asm/DelegateGenerator.java
@@ -150,7 +150,7 @@ public class DelegateGenerator {
         
         //The returned MethodVisitor will visit the original version of the method,
         //including its annotation, where we can get StorageOptions.
-        return new MethodVisitor(Opcodes.ASM4, 
+        return new MethodVisitor(Opcodes.ASM5, 
                 parentClass.visitMethod(Opcodes.ACC_PUBLIC + Opcodes.ACC_STATIC, delegateFunctionName, desc, null, null)) {
             
             //Remember storage options for each argument
@@ -387,7 +387,7 @@ public class DelegateGenerator {
         
         //The returned MethodVisitor will visit the original version of the method,
         //including its annotation, where we can get StorageOptions.
-        return new MethodVisitor(Opcodes.ASM4, 
+        return new MethodVisitor(Opcodes.ASM5, 
                 parentClass.visitMethod(Opcodes.ACC_PUBLIC + Opcodes.ACC_STATIC, delegateMethodName, nonstaticDesc, null, null)) {
             
             //Remember storage options for each argument

--- a/src/main/java/cn/annoreg/asm/RegistryTransformer.java
+++ b/src/main/java/cn/annoreg/asm/RegistryTransformer.java
@@ -45,7 +45,7 @@ public class RegistryTransformer implements IClassTransformer {
     		
     		//Get inner class list for each class
     		{
-    	        InnerClassVisitor cv = new InnerClassVisitor(Opcodes.ASM4);
+    	        InnerClassVisitor cv = new InnerClassVisitor(Opcodes.ASM5);
     	        cr.accept(cv, 0);
     	        List<String> inner = cv.getInnerClassList();
     	        if (inner != null) {
@@ -54,10 +54,10 @@ public class RegistryTransformer implements IClassTransformer {
     		}
     		//Transform network-calls for each class
     		{
-    		    NetworkCallVisitor cv = new NetworkCallVisitor(Opcodes.ASM4, arg0);
+    		    NetworkCallVisitor cv = new NetworkCallVisitor(Opcodes.ASM5, arg0);
     		    cr.accept(cv, 0);
     	        if (cv.needTransform()) {
-    	            ClassWriter cw = new ClassWriter(Opcodes.ASM4);
+    	            ClassWriter cw = new ClassWriter(Opcodes.ASM5);
     	            cr.accept(cv.getTransformer(cw), 0);
     	            data = cw.toByteArray();
     	        }


### PR DESCRIPTION
Using ASM4 breaks mods built for java 8 causing issues like cout970/Magneticraft-API-and-Issues#54. Version of forge this lib is using includes ASM5 so there is no reason to use ASM4.

Also this may be a symptom of much deeper problems, so you should rethink what you're doing here.
